### PR TITLE
MGMT-9789 Validation of the default network types

### DIFF
--- a/packages/integration-tests/README.md
+++ b/packages/integration-tests/README.md
@@ -16,8 +16,6 @@ It's important to mock the API accurately to avoid having passing UI tests that 
 
 - Start the standalone Assisted Installer UI application running in the specified `baseUrl`
 
-- Execute the cypress command:
-   yarn cypress-open
 
 # Environment variables configuration:
 
@@ -46,7 +44,7 @@ cypress.env.json
 The project defines two ways to run the tests:
 
 `integration-tests:run`: Runs the tests within headless mode Cypress
-`integration-tests:open`: Opens Cypress and lets you select which tests to run
+`integration-tests:open`: Opens the Cypress UI and lets you select which tests to run
 
 
 # Linting

--- a/packages/integration-tests/README.md
+++ b/packages/integration-tests/README.md
@@ -43,11 +43,11 @@ cypress.env.json
 
 # How to run the tests
 
-Run `yarn ui-tests:open` to be able to select the tests you want to run
-Run `yarn ui-tests:run` to run all of the tests
+The project defines two ways to run the tests:
+
+`integration-tests:run`: Runs the tests within headless mode Cypress
+`integration-tests:open`: Opens Cypress and lets you select which tests to run
 
 
 # Linting
-
 TODO
-From the root repository folder, run `yarn ui-tests:open`

--- a/packages/integration-tests/src/integration/create-multinode/2-networking.spec.js
+++ b/packages/integration-tests/src/integration/create-multinode/2-networking.spec.js
@@ -58,6 +58,12 @@ describe(`Assisted Installer Multinode Networking`, () => {
       networkingPage.getStackTypeInput().should('be.disabled');
     });
 
+    it('Should have the correct default network type', () => {
+      networkingPage.getAdvancedNetwork().click();
+      networkingPage.getSdnNetworkingField().should('be.enabled').and('be.checked');
+      networkingPage.getOvnNetworkingField().should('be.enabled').and('not.be.checked');
+    });
+
     it('Should go to the final step', () => {
       commonActions.clickNextButton();
     });

--- a/packages/integration-tests/src/integration/create-sno/2-networking.spec.js
+++ b/packages/integration-tests/src/integration/create-sno/2-networking.spec.js
@@ -60,6 +60,12 @@ describe(`Assisted Installer SNO Networking`, () => {
       networkingPage.getAdvancedNetwork().should('not.be.checked');
     });
 
+    it('Should have the correct default network type', () => {
+      networkingPage.getAdvancedNetwork().click();
+      networkingPage.getSdnNetworkingField().should('not.be.enabled').and('not.be.checked');
+      networkingPage.getOvnNetworkingField().should('be.enabled').and('be.checked');
+    });
+
     it('Should go to the final step', () => {
       commonActions.clickNextButton();
     });

--- a/packages/integration-tests/src/integration/ui-behaviour/cluster-updates.spec.js
+++ b/packages/integration-tests/src/integration/ui-behaviour/cluster-updates.spec.js
@@ -22,7 +22,7 @@ describe('Assisted Installer UI behaviour', () => {
 
       navbar.clickOnNavItem('Cluster details');
       commonActions.clickNextButton();
-      commonActions.getHeader().should('contain', 'Host discovery');
+      commonActions.getHeader('h2').should('contain', 'Host discovery');
     });
   });
 });


### PR DESCRIPTION
Related to issue https://issues.redhat.com/browse/MGMT-9789

Validating that the default network types are the expected ones, for both SNO and Multinode clusters.