### PR TITLE
Fix: Cluster names and active scenarios

### DIFF
--- a/packages/integration-tests/src/fixtures/cluster-list/index.js
+++ b/packages/integration-tests/src/fixtures/cluster-list/index.js
@@ -10,13 +10,13 @@ const fakeCluster = {
   href: `/api/assisted-install/v2/clusters/${fakeClusterId}`,
 };
 
-const addedCluster = {
+const addedCluster = () => ({
   ...clusterTemplate,
   name: Cypress.env('CLUSTER_NAME'),
-};
+});
 
 const initialList = [fakeCluster];
 
-const updatedList = [addedCluster, fakeCluster];
+const updatedList = () => ([addedCluster(), fakeCluster]);
 
 export { initialList, updatedList };

--- a/packages/integration-tests/src/fixtures/create-sno/index.js
+++ b/packages/integration-tests/src/fixtures/create-sno/index.js
@@ -4,9 +4,7 @@ import { hostDiscoveredBuilder } from './3-host-discovered';
 import { hostRenamedBuilder } from './4-host-renamed';
 import { clusterReadyBuilder } from './5-cluster-ready';
 
-const clusterName = Cypress.env('CLUSTER_NAME');
-
-const initialCluster = getSnoCluster({ name: clusterName });
+const initialCluster = getSnoCluster({ name: "ai-e2e-sno" });
 const isoDownloadedCluster = isoDownloadedClusterBuilder(initialCluster);
 const hostDiscoveredCluster = hostDiscoveredBuilder(isoDownloadedCluster);
 const hostRenamedCluster = hostRenamedBuilder(hostDiscoveredCluster);

--- a/packages/integration-tests/src/integration/create-multinode/3-review.spec.js
+++ b/packages/integration-tests/src/integration/create-multinode/3-review.spec.js
@@ -6,7 +6,7 @@ import { transformBasedOnUIVersion } from '../../support/transformations';
 describe(`Assisted Installer Multinode Review`, () => {
   before(() => {
     transformBasedOnUIVersion();
-    cy.loadAiAPIIntercepts({ activeSignal: 'READY_TO_INSTALL', activeScenario: 'AI_CREATE_SNO' });
+    cy.loadAiAPIIntercepts({ activeSignal: 'READY_TO_INSTALL', activeScenario: 'AI_CREATE_MULTINODE' });
   });
 
   beforeEach(() => {

--- a/packages/integration-tests/src/support/interceptors.js
+++ b/packages/integration-tests/src/support/interceptors.js
@@ -49,12 +49,18 @@ const setScenarioEnvVars = ({ activeScenario }) => {
 
   switch (activeScenario) {
     case 'AI_CREATE_SNO':
+      Cypress.env('CLUSTER_NAME', 'ai-e2e-sno');
       Cypress.env('ASSISTED_SNO_DEPLOYMENT', true);
       Cypress.env('NUM_MASTERS', 1);
       Cypress.env('NUM_WORKERS', 0);
       break;
     case 'AI_CREATE_MULTINODE':
+      Cypress.env('CLUSTER_NAME', 'ai-e2e-multinode');
       Cypress.env('ASSISTED_SNO_DEPLOYMENT', false);
+      break;
+    case 'AI_READONLY_CLUSTER':
+      Cypress.env('ASSISTED_SNO_DEPLOYMENT', false);
+      Cypress.env('CLUSTER_NAME', 'ai-e2e-readonly');
       break;
     default:
       break;
@@ -67,7 +73,7 @@ const addClusterCreationIntercepts = () => {
 
 const addClusterListIntercepts = () => {
   cy.intercept('GET', allClustersApiPath, (req) => {
-    const fixture = hasWizardSignal('CLUSTER_CREATED') ? updatedList : initialList;
+    const fixture = hasWizardSignal('CLUSTER_CREATED') ? updatedList() : initialList;
     req.reply(fixture);
   });
 };


### PR DESCRIPTION
While porting the DS tests, I noticed the cluster names often didn't match the scenario.

In this PR, I:

- set the `CLUSTER_NAME` as part of the `setScenarioEnvVars` function, so that they are inputted correctly when we mock the cluster creation
- make `updatedList` a function so that the added cluster has the correct name
- set the correct scenario for the MNO cluster Review page
- set the SNO cluster name explicitly (like in all other cases)