### PR TITLE
Add version to package.json

### DIFF
--- a/packages/integration-tests/package.json
+++ b/packages/integration-tests/package.json
@@ -1,5 +1,6 @@
 {
   "name": "openshift-assisted-ui-integration-tests",
+  "version": "0.0.1",
   "private": false,
   "license": "Apache-2.0",
   "dependencies": {


### PR DESCRIPTION
Without the version, **yarn install** won't install the node modules inside the **integration-tests**.