### PR TITLE
Adapt dual-stack tests for 2.9

### DIFF
--- a/packages/integration-tests/src/fixtures/dualstack/1-cluster-created.ts
+++ b/packages/integration-tests/src/fixtures/dualstack/1-cluster-created.ts
@@ -58,7 +58,7 @@ const dualstackClusterBase = {
   high_availability_mode: 'Full',
   network_type: 'OpenShiftSDN',
   user_managed_networking: false,
-  vip_dhcp_allocation: true,
+  vip_dhcp_allocation: false,
   connectivity_majority_groups: JSON.stringify(connectivityMajorityGroups),
   validations_info: JSON.stringify(clusterValidationsInfo),
   enabled_host_count: 3,

--- a/packages/integration-tests/src/fixtures/dualstack/index.ts
+++ b/packages/integration-tests/src/fixtures/dualstack/index.ts
@@ -7,8 +7,6 @@ const readyToInstallCluster = clusterReadyBuilder(dualstackClusterBase);
 const readyToInstallDualstackCluster = clusterDualstackBuilder(readyToInstallCluster);
 
 const singleStackEnhancements = {
-  api_vip: '192.168.122.10',
-  ingress_vip: '192.168.122.110',
   feature_usage: JSON.stringify(featureUsage),
   e2e_mock_source: '5-dualstack-ipv4',
   status: 'ready',

--- a/packages/integration-tests/src/fixtures/dualstack/requests.ts
+++ b/packages/integration-tests/src/fixtures/dualstack/requests.ts
@@ -4,14 +4,11 @@ import { fakeClusterId } from '../cluster/base-cluster';
 
 export const ipv4NetworkingRequest = {
   ssh_public_key: '',
-  vip_dhcp_allocation: true,
+  vip_dhcp_allocation: false,
+  api_vip: '192.168.122.10',
+  ingress_vip: '192.168.122.110',
   network_type: 'OpenShiftSDN',
-  machine_networks: [
-    {
-      cidr: '192.168.122.0/24',
-      cluster_id: fakeClusterId,
-    },
-  ],
+  machine_networks: [],
   cluster_networks: [
     {
       cidr: '10.128.0.0/14',

--- a/packages/integration-tests/src/integration/dualstack/2-networking.spec.ts
+++ b/packages/integration-tests/src/integration/dualstack/2-networking.spec.ts
@@ -28,7 +28,11 @@ describe(`Assisted Installer Dualstack Networking`, () => {
   it('Can correctly configure IPv4 networking type', () => {
     networkingPage.getStackTypeSingleStack().should('be.enabled').and('be.checked');
     networkingPage.getClusterManagedNetworking().should('be.enabled').and('be.checked');
-    networkingPage.getVipDhcp().should('be.enabled').and('be.checked');
+    networkingPage.getVipDhcp().should('be.enabled').and('not.be.checked');
+
+    networkingPage.getApiVipField().type('192.168.122.10');
+    networkingPage.getIngressVipField().type('192.168.122.110')
+
     networkingPage.getAdvancedNetwork().should('be.enabled').and('not.be.checked');
 
     utils.setTransformSignal('single-stack');
@@ -63,7 +67,7 @@ describe(`Assisted Installer Dualstack Networking`, () => {
 
     networkingPage.getClusterManagedNetworking().should('be.enabled').and('be.checked');
     networkingPage.getStackTypeSingleStack().should('be.enabled').and('be.checked');
-    networkingPage.getVipDhcp().should('be.enabled').and('be.checked');
+    networkingPage.getVipDhcp().should('be.enabled').and('not.be.checked');
     networkingPage.getSdnNetworkingField().should('be.enabled').and('be.checked');
   });
 });


### PR DESCRIPTION
Adaptations for Assisted UI lib v2.9.0 regarding the Networking step:
- DHCP is off by default and the user has to input IP/Ingress IPs manually.
- IPv4 stack with DHCP off sends an empty `machineNetworks` array.