### PR TITLE
MGMT-12121: Adaptation for changes in OpenShift version dropdown

### DIFF
--- a/packages/integration-tests/src/support/utils.ts
+++ b/packages/integration-tests/src/support/utils.ts
@@ -72,11 +72,3 @@ export const setHostsRole = (
     cy.get(hostDetailSelector(i, 'Role')).click().find('li#worker').click();
   }
 };
-
-export const isVersionIncluding = (testVersion, minVersion) => {
-  const semver = Cypress.env('semver');
-  return semver.gte(
-    semver.valid(semver.coerce(testVersion)),
-    semver.valid(semver.coerce(minVersion)),
-  );
-};

--- a/packages/integration-tests/src/support/utils.ts
+++ b/packages/integration-tests/src/support/utils.ts
@@ -36,11 +36,15 @@ export const getTransformSignal = (): SignalName | undefined => Cypress.env('TRA
 
 export const getUiVersion = () => {
   return new Cypress.Promise((resolve) => {
-    cy.newByDataTestId('assisted-ui-lib-version')
-      .invoke('text')
-      .then((uiVersion) => {
-        resolve(uiVersion);
-      });
+    if (Cypress.env('AI_MOCKED_UI_VERSION')) {
+      resolve(Cypress.env('AI_MOCKED_UI_VERSION'));
+    } else {
+      cy.newByDataTestId('assisted-ui-lib-version')
+        .invoke('text')
+        .then((uiVersion) => {
+          resolve(uiVersion);
+        });
+    }
   });
 };
 
@@ -67,4 +71,12 @@ export const setHostsRole = (
   for (let i = 2 + numMasters; i < 2 + numMasters + numWorkers; i++) {
     cy.get(hostDetailSelector(i, 'Role')).click().find('li#worker').click();
   }
+};
+
+export const isVersionIncluding = (testVersion, minVersion) => {
+  const semver = Cypress.env('semver');
+  return semver.gte(
+    semver.valid(semver.coerce(testVersion)),
+    semver.valid(semver.coerce(minVersion)),
+  );
 };

--- a/packages/integration-tests/src/support/variables/cluster-details.ts
+++ b/packages/integration-tests/src/support/variables/cluster-details.ts
@@ -1,9 +1,6 @@
-import * as semver from 'semver';
 /*
 VARIABLES
  */
-// assign packages to env var for access and use accross all files
-Cypress.env('semver', semver);
 Cypress.env('clusterNameFieldValidator', `[aria-label='Validation']`);
 Cypress.env('clusterNameFieldId', '#form-input-name-field');
 Cypress.env('openshiftVersionFieldId', '#form-input-openshiftVersion-field');

--- a/packages/integration-tests/src/support/variables/cluster-details.ts
+++ b/packages/integration-tests/src/support/variables/cluster-details.ts
@@ -1,3 +1,9 @@
+import * as semver from 'semver';
+/*
+VARIABLES
+ */
+// assign packages to env var for access and use accross all files
+Cypress.env('semver', semver);
 Cypress.env('clusterNameFieldValidator', `[aria-label='Validation']`);
 Cypress.env('clusterNameFieldId', '#form-input-name-field');
 Cypress.env('openshiftVersionFieldId', '#form-input-openshiftVersion-field');

--- a/packages/integration-tests/src/support/variables/common.ts
+++ b/packages/integration-tests/src/support/variables/common.ts
@@ -13,3 +13,4 @@ Cypress.env('dangerAlertAriaLabel', 'div[aria-label="Danger Alert"]');
 Cypress.env('clusterListAriaLabel', `table[aria-label="Cluster List"]`);
 Cypress.env('copyableInputAriaLabel', `[aria-label='Copyable input']`);
 Cypress.env('dataLayerContent', '[data-layer="Content"]');
+Cypress.env('AI_MOCKED_UI_VERSION','2.11.0');

--- a/packages/integration-tests/src/views/clusterDetails.ts
+++ b/packages/integration-tests/src/views/clusterDetails.ts
@@ -1,4 +1,3 @@
-import { getUiVersion, isVersionIncluding } from '../support/utils';
 export const clusterDetailsPage = {
   getClusterNameField: () => {
     return cy.get(Cypress.env('clusterNameFieldId'));

--- a/packages/integration-tests/src/views/clusterDetails.ts
+++ b/packages/integration-tests/src/views/clusterDetails.ts
@@ -1,3 +1,4 @@
+import { getUiVersion, isVersionIncluding } from '../support/utils';
 export const clusterDetailsPage = {
   getClusterNameField: () => {
     return cy.get(Cypress.env('clusterNameFieldId'));
@@ -8,18 +9,16 @@ export const clusterDetailsPage = {
   getOpenshiftVersionField: () => {
     return cy.get(Cypress.env('openshiftVersionFieldId'));
   },
-  inputOpenshiftVersion: (version = Cypress.env('OPENSHIFT_VERSION')) => {
-    // select option based on option.val() == version
-    cy.get(`#form-input-openshiftVersion-field > option`).each((option) => {
-      if (option.text().includes(version)) {
-        clusterDetailsPage.getOpenshiftVersionField().select(option.text());
-        // Stop iteration after first match for given X.Y version.
-        // OpenShift versions are (currently) listed is descending order starting from newest.
-        return false;
-      }
-      return true;
+  inputOpenshiftVersion: (version = Cypress.env('OPENSHIFT_VERSION')) => {   
+    // since version 2.11 we change the openshiftVersion dropdown
+    cy.get(`#form-input-openshiftVersion-field > button.pf-c-dropdown__toggle`).click();
+    cy.get(`ul.pf-c-dropdown__menu`).within(() => {
+      cy.get('li').contains(version).click();
     });
-    clusterDetailsPage.getOpenshiftVersionField().should('contain', `OpenShift ${version}`);
+    cy.get(`#form-input-openshiftVersion-field .pf-c-dropdown__toggle-text`).should(
+      'contain',
+      `OpenShift ${version}`,
+    );
   },
   getPullSecret: () => {
     return cy.get(Cypress.env('pullSecretFieldId'));


### PR DESCRIPTION
Adaptations for 2.11: changes in OpenShift version dropdown

Related to :

- PR assisted-ui-lib: https://github.com/openshift-assisted/assisted-ui-lib/pull/1656
- Link to Jira: https://issues.redhat.com/browse/MGMT-12121

I prepare the code to allow different versions from UI. At the moment is not necessary but maybe if we put our integration tests inside CI we need these changes.
