### PR TITLE
Adaptations for v2.12 - dual stack tests are now independent

### DIFF
--- a/packages/integration-tests/src/fixtures/dualstack/5-cluster-ready.ts
+++ b/packages/integration-tests/src/fixtures/dualstack/5-cluster-ready.ts
@@ -1,110 +1,13 @@
 /* eslint-disable @typescript-eslint/naming-convention */
 
 import { clusterValidationsInfo } from '../cluster/validation-info-cluster-ready';
-import { fakeClusterId } from '../cluster/base-cluster';
-import { hostIds } from '../hosts';
-
-const featureUsageDualstack = {
-  'OVN network type': {
-    id: 'OVN_NETWORK_TYPE',
-    name: 'OVN network type',
-  },
-  'Requested hostname': {
-    data: {
-      host_count: 3,
-    },
-    id: 'REQUESTED_HOSTNAME',
-    name: 'Requested hostname',
-  },
-  'Dual-stack': {
-    id: 'DUAL-STACK',
-    name: 'Dual-stack',
-  },
-};
 
 const clusterReadyBuilder = (baseCluster) => ({
   ...baseCluster,
-  e2e_mock_source: '5-dualstack-ipv4',
+  e2e_mock_source: '5-dualstack-dual-stack',
   status: 'ready',
   status_info: 'Cluster ready to be installed',
   validations_info: JSON.stringify(clusterValidationsInfo),
-  api_vip: '192.168.122.10',
-  ingress_vip: '192.168.122.110',
-  cluster_networks: [
-    {
-      cidr: '10.128.0.0/14',
-      cluster_id: fakeClusterId,
-      host_prefix: 23,
-    },
-  ],
-  service_networks: [
-    {
-      cidr: '172.30.0.0/16',
-      cluster_id: fakeClusterId,
-    },
-  ],
-  machine_networks: [
-    {
-      cidr: '192.168.122.0/24',
-      cluster_id: fakeClusterId,
-    },
-  ],
 });
 
-const clusterDualstackBuilder = (baseCluster) => ({
-  ...baseCluster,
-  cluster_networks: [
-    {
-      cidr: '10.128.0.0/14',
-      cluster_id: fakeClusterId,
-      host_prefix: 23,
-    },
-    {
-      cidr: 'fd01::/48',
-      cluster_id: fakeClusterId,
-      host_prefix: 64,
-    },
-  ],
-  service_networks: [
-    {
-      cidr: '172.30.0.0/16',
-      cluster_id: fakeClusterId,
-    },
-    {
-      cidr: 'fd02::/112',
-      cluster_id: fakeClusterId,
-    },
-  ],
-  machine_networks: [
-    {
-      cidr: '192.168.122.0/24',
-      cluster_id: fakeClusterId,
-    },
-    {
-      cidr: '1001:db9::/120',
-      cluster_id: fakeClusterId,
-    },
-  ],
-  host_networks: [
-    {
-      cidr: '192.168.122.0/24',
-      host_ids: hostIds,
-    },
-    {
-      cidr: '1001:db9::/120',
-      host_ids: hostIds,
-    },
-  ],
-  api_vip: '192.168.122.10',
-  ingress_vip: '192.168.122.110',
-  // We're adding this field to easily debug which mock is returning the response
-  e2e_mock_source: '1-dualstack-dualstack',
-  feature_usage: JSON.stringify(featureUsageDualstack),
-  validations_info: JSON.stringify(clusterValidationsInfo),
-  high_availability_mode: 'Full',
-  network_type: 'OVNKubernetes',
-  user_managed_networking: false,
-  vip_dhcp_allocation: false,
-});
-
-export { clusterReadyBuilder, clusterDualstackBuilder, featureUsageDualstack };
+export { clusterReadyBuilder };

--- a/packages/integration-tests/src/fixtures/dualstack/index.ts
+++ b/packages/integration-tests/src/fixtures/dualstack/index.ts
@@ -1,27 +1,15 @@
 /* eslint-disable @typescript-eslint/naming-convention */
+import { dualstackClusterBase, withDualStackNetworks } from './1-network-ready';
+import { clusterReadyBuilder } from './5-cluster-ready';
 
-import { dualstackClusterBase, featureUsage } from './1-cluster-created';
-import { clusterReadyBuilder, clusterDualstackBuilder, featureUsageDualstack } from './5-cluster-ready';
-
-const readyToInstallCluster = clusterReadyBuilder(dualstackClusterBase);
-const readyToInstallDualstackCluster = clusterDualstackBuilder(readyToInstallCluster);
-
-const singleStackEnhancements = {
-  feature_usage: JSON.stringify(featureUsage),
-  e2e_mock_source: '5-dualstack-ipv4',
-  status: 'ready',
-  status_info: 'Cluster ready to be installed',
-};
-
-const dualStackEnhancements = {
-  feature_usage: JSON.stringify(featureUsageDualstack),
-};
+const dualStackSelectedCluster = withDualStackNetworks(dualstackClusterBase);
+const readyToInstallCluster = clusterReadyBuilder(dualStackSelectedCluster);
 
 const createDualStackFixtureMapping = {
-  HOST_RENAMED_3: dualstackClusterBase,
+  NETWORKING_DUAL_STACK_DISCOVERED: dualstackClusterBase,
+  NETWORKING_DUAL_STACK_SELECT_SINGLE_STACK: dualstackClusterBase,
+  NETWORKING_DUAL_STACK_SELECT_DUAL_STACK: dualStackSelectedCluster,
   READY_TO_INSTALL: readyToInstallCluster,
-  READY_TO_INSTALL_DUALSTACK: readyToInstallDualstackCluster,
-  default: dualstackClusterBase,
 };
 
-export { createDualStackFixtureMapping, singleStackEnhancements, dualStackEnhancements };
+export { createDualStackFixtureMapping };

--- a/packages/integration-tests/src/fixtures/dualstack/requests.ts
+++ b/packages/integration-tests/src/fixtures/dualstack/requests.ts
@@ -7,7 +7,7 @@ export const ipv4NetworkingRequest = {
   vip_dhcp_allocation: false,
   api_vip: '192.168.122.10',
   ingress_vip: '192.168.122.110',
-  network_type: 'OpenShiftSDN',
+  network_type: 'OVNKubernetes',
   machine_networks: [],
   cluster_networks: [
     {

--- a/packages/integration-tests/src/fixtures/hosts/index.ts
+++ b/packages/integration-tests/src/fixtures/hosts/index.ts
@@ -41,10 +41,10 @@ const getUpdatedHosts = () => {
   let transformer: (index: number) => Record<string, unknown>;
   if (/HOST_DISCOVERED_\d/.test(lastSignal)) {
     transformer = (index) => discoveredHosts[index];
-  } else if (/HOST_RENAMED_\d/.test(lastSignal)) {
-    transformer = getRenamedHost;
   } else if (hasWizardSignal('READY_TO_INSTALL')) {
     transformer = (index) => hostReady(getRenamedHost(index));
+  } else {
+    transformer = getRenamedHost;
   }
 
   return new Array(discoveredHostsCount).fill(0).map((_, index) => {

--- a/packages/integration-tests/src/integration/dualstack/2-networking.spec.ts
+++ b/packages/integration-tests/src/integration/dualstack/2-networking.spec.ts
@@ -1,73 +1,71 @@
 import { commonActions } from '../../views/common';
 import { networkingPage } from '../../views/networkingPage';
 import * as utils from '../../support/utils';
+import { dualStackNetworkingRequest, ipv4NetworkingRequest } from '../../fixtures/dualstack/requests';
 
 describe(`Assisted Installer Dualstack Networking`, () => {
-  before(() => {
-    cy.loadAiAPIIntercepts({
-      activeSignal: 'HOST_RENAMED_3',
-      activeScenario: 'AI_CREATE_DUALSTACK',
-    });
-  });
-
   beforeEach(() => {
     cy.loadAiAPIIntercepts(null);
     commonActions.visitClusterDetailsPage();
     commonActions.startAtNetworkingStep();
   });
 
-  afterEach(() => {
-    commonActions.waitForSave();
-    commonActions.getNextButton().should('be.enabled');
-  });
+  describe('Cluster configured with Single Stack', () => {
+    before(() => {
+      cy.loadAiAPIIntercepts({
+        activeSignal: 'NETWORKING_DUAL_STACK_DISCOVERED',
+        activeScenario: 'AI_CREATE_DUALSTACK',
+      });
+    });
+    it('Networking is displayed correctly', () => {
+      networkingPage.getStackTypeSingleStack().should('be.enabled').and('be.checked');
+      networkingPage.getClusterManagedNetworking().should('be.enabled').and('be.checked');
+      networkingPage.getVipDhcp().should('be.enabled').and('not.be.checked');
 
-  after('Should go to the final step', () => {
-    commonActions.clickNextButton();
-  });
+      networkingPage.getAdvancedNetwork().should('be.enabled').and('not.be.checked');
+    });
 
-  it('Can correctly configure IPv4 networking type', () => {
-    networkingPage.getStackTypeSingleStack().should('be.enabled').and('be.checked');
-    networkingPage.getClusterManagedNetworking().should('be.enabled').and('be.checked');
-    networkingPage.getVipDhcp().should('be.enabled').and('not.be.checked');
+    it('Can switch to dual-stack', () => {
+      networkingPage.getStackTypeDualStack().should('be.enabled').and('not.be.checked');
+      networkingPage.getStackTypeDualStack().check();
 
-    networkingPage.getApiVipField().type('192.168.122.10');
-    networkingPage.getIngressVipField().type('192.168.122.110')
+      cy.wait('@update-cluster').then(({ request }) => {
+        expect(request.body, 'Networking request body').to.deep.equal(dualStackNetworkingRequest);
+        utils.setLastWizardSignal('NETWORKING_DUAL_STACK_SELECT_DUAL_STACK');
+      });
 
-    networkingPage.getAdvancedNetwork().should('be.enabled').and('not.be.checked');
-
-    utils.setTransformSignal('single-stack');
-    cy.wait('@update-cluster').then(() => {
-      utils.setLastWizardSignal('READY_TO_INSTALL');
-      utils.clearTransformSignal();
+      networkingPage.getStackTypeDualStack().should('be.enabled').and('be.checked');
+      networkingPage.getClusterManagedNetworking().should('be.disabled').and('be.checked');
+      networkingPage.getVipDhcp().should('be.disabled').and('not.be.checked');
+      networkingPage.getOvnNetworkingField().should('be.enabled').and('be.checked');
+      networkingPage.getSdnNetworkingField().should('be.disabled');
+      networkingPage.waitForNetworkStatusToNotContain('Some validations failed');
     });
   });
 
-  it('Can switch to dual-stack networking type', () => {
-    networkingPage.getStackTypeDualStack().should('be.enabled').and('not.be.checked');
-    networkingPage.getStackTypeDualStack().check();
+  describe('Cluster configured with Dual Stack', () => {
+    before(() => {
+      cy.loadAiAPIIntercepts({
+        activeSignal: 'NETWORKING_DUAL_STACK_SELECT_DUAL_STACK',
+        activeScenario: 'AI_CREATE_DUALSTACK',
+      });
+    });
 
-    utils.setTransformSignal('dual-stack');
-    cy.wait('@update-cluster');
+    it('Can switch to single-stack', () => {
+      networkingPage.getStackTypeDualStack().should('be.enabled').and('be.checked');
+      networkingPage.getStackTypeSingleStack().should('be.enabled').check();
+      networkingPage.confirmStackTypeChange();
 
-    networkingPage.getClusterManagedNetworking().should('be.disabled').and('be.checked');
-    networkingPage.getStackTypeDualStack().should('be.enabled').and('be.checked');
-    networkingPage.getVipDhcp().should('be.disabled').and('not.be.checked');
-    networkingPage.getOvnNetworkingField().should('be.enabled').and('be.checked');
-    networkingPage.getSdnNetworkingField().should('be.disabled');
-    networkingPage.waitForNetworkStatusToNotContain('Some validations failed');
-  });
+      cy.wait('@update-cluster').then(({ request }) => {
+        expect(request.body, 'Networking request body').to.deep.equal(ipv4NetworkingRequest);
+        utils.setLastWizardSignal('NETWORKING_DUAL_STACK_SELECT_SINGLE_STACK');
+      });
 
-  it('Can switch to IPv4 networking type', () => {
-    networkingPage.getStackTypeDualStack().should('be.enabled').and('be.checked');
-    networkingPage.getStackTypeSingleStack().should('be.enabled').check();
-    networkingPage.confirmStackTypeChange();
-
-    utils.setTransformSignal('single-stack');
-    cy.wait('@update-cluster');
-
-    networkingPage.getClusterManagedNetworking().should('be.enabled').and('be.checked');
-    networkingPage.getStackTypeSingleStack().should('be.enabled').and('be.checked');
-    networkingPage.getVipDhcp().should('be.enabled').and('not.be.checked');
-    networkingPage.getSdnNetworkingField().should('be.enabled').and('be.checked');
+      networkingPage.getClusterManagedNetworking().should('be.enabled').and('be.checked');
+      networkingPage.getStackTypeSingleStack().should('be.enabled').and('be.checked');
+      networkingPage.getVipDhcp().should('be.disabled').and('not.be.checked');
+      networkingPage.getOvnNetworkingField().should('be.enabled').and('be.checked');
+      networkingPage.getSdnNetworkingField().should('be.enabled').and('not.be.checked');
+    });
   });
 });

--- a/packages/integration-tests/src/integration/dualstack/3-review.spec.ts
+++ b/packages/integration-tests/src/integration/dualstack/3-review.spec.ts
@@ -4,7 +4,7 @@ import { commonActions } from '../../views/common';
 describe(`Assisted Installer Dualstack Review`, () => {
   before(() => {
     cy.loadAiAPIIntercepts({
-      activeSignal: 'READY_TO_INSTALL_DUALSTACK',
+      activeSignal: 'READY_TO_INSTALL',
       activeScenario: 'AI_CREATE_DUALSTACK',
     });
   });

--- a/packages/integration-tests/src/support/interceptors.ts
+++ b/packages/integration-tests/src/support/interceptors.ts
@@ -1,10 +1,4 @@
-import {
-  hasWizardSignal,
-  setLastWizardSignal,
-  getTransformSignal,
-  clearTransformSignal,
-  TransformSignal,
-} from './utils';
+import { hasWizardSignal, setLastWizardSignal } from './utils';
 import { fakeClusterId, fakeClusterInfraEnvId } from '../fixtures/cluster/base-cluster';
 import { hostIds, getUpdatedHosts } from '../fixtures/hosts';
 import openShiftVersions from '../fixtures/infra-envs/openshift-versions';
@@ -18,8 +12,7 @@ import createSnoFixtureMapping from '../fixtures/create-sno';
 import createMultinodeFixtureMapping from '../fixtures/create-mn';
 import createReadOnlyClusterFixtureMapping from '../fixtures/read-only';
 import createStorageFixtureMapping from '../fixtures/storage';
-import { createDualStackFixtureMapping, singleStackEnhancements, dualStackEnhancements } from '../fixtures/dualstack';
-import { dualStackNetworkingRequest, ipv4NetworkingRequest } from '../fixtures/dualstack/requests';
+import { createDualStackFixtureMapping } from '../fixtures/dualstack';
 
 const allInfraEnvsApiPath = '/api/assisted-install/v2/infra-envs/';
 const allClustersApiPath = '/api/assisted-install/v2/clusters/';
@@ -27,32 +20,9 @@ const allClustersApiPath = '/api/assisted-install/v2/clusters/';
 const infraEnvApiPath = `${allInfraEnvsApiPath}${fakeClusterInfraEnvId}`;
 const clusterApiPath = `${allClustersApiPath}${fakeClusterId}`;
 
-const getPatchEnhancements = (activeTransformSignal: TransformSignal | undefined, signalRequest) => {
-  let enhancements = {};
-
-  switch (activeTransformSignal) {
-    case 'single-stack':
-      expect(signalRequest, 'Networking request body').to.deep.equal(ipv4NetworkingRequest);
-      enhancements = singleStackEnhancements;
-      break;
-    case 'dual-stack':
-      expect(signalRequest, 'Networking request body').to.deep.equal(dualStackNetworkingRequest);
-      enhancements = dualStackEnhancements;
-      break;
-    default:
-      break;
-  }
-  return { ...signalRequest, ...enhancements };
-};
-
 const transformClusterFixture = (req, fixtureMapping) => {
-  let baseCluster = fixtureMapping[Cypress.env('AI_LAST_SIGNAL')] || fixtureMapping['default'];
+  const baseCluster = fixtureMapping[Cypress.env('AI_LAST_SIGNAL')] || fixtureMapping['default'];
 
-  const activeTransformSignal = getTransformSignal();
-
-  if (activeTransformSignal && req.method === 'PATCH') {
-    baseCluster = { ...baseCluster, ...getPatchEnhancements(activeTransformSignal, req.body) };
-  }
   const hosts = fixtureMapping.staticHosts || getUpdatedHosts();
   return { ...baseCluster, hosts };
 };
@@ -92,7 +62,6 @@ const mockClusterResponse = (req) => {
 
 const setScenarioEnvVars = ({ activeScenario }) => {
   Cypress.env('AI_SCENARIO', activeScenario);
-  clearTransformSignal();
 
   switch (activeScenario) {
     case 'AI_CREATE_SNO':

--- a/packages/integration-tests/src/support/utils.ts
+++ b/packages/integration-tests/src/support/utils.ts
@@ -1,4 +1,10 @@
+/**
+ * The signal order determinesa sequence of events.
+ * When a signal is given, it is implied that the previous steps
+ * have already taken place
+ */
 const signalOrder = [
+  // For general cluster creation flow
   'CLUSTER_CREATED',
   'ISO_DOWNLOADED',
   'HOST_DISCOVERED_1',
@@ -7,12 +13,18 @@ const signalOrder = [
   'HOST_RENAMED_2',
   'HOST_DISCOVERED_3',
   'HOST_RENAMED_3',
+
+  // Networking signals
+  // - Dual Stack
+  'NETWORKING_DUAL_STACK_DISCOVERED',
+  'NETWORKING_DUAL_STACK_SELECT_SINGLE_STACK',
+  'NETWORKING_DUAL_STACK_SELECT_DUAL_STACK',
+
+  // Last signal must always be Ready to install
   'READY_TO_INSTALL',
-  'READY_TO_INSTALL_DUALSTACK',
 ];
 
 export type SignalName = typeof signalOrder[number];
-export type TransformSignal = 'dual-stack' | 'single-stack';
 
 export const setLastWizardSignal = (signalName: SignalName) => {
   Cypress.env('AI_LAST_SIGNAL', signalName);
@@ -24,16 +36,6 @@ export const hasWizardSignal = (signalName: SignalName) => {
   const reqSignalOrder = signalOrder.findIndex((signal) => signal === signalName);
   return reqSignalOrder !== -1 && reqSignalOrder <= currentSignalOrder;
 };
-
-export const setTransformSignal = (transformSignal: TransformSignal) => {
-  Cypress.env('TRANSFORM_SIGNAL', transformSignal);
-};
-
-export const clearTransformSignal = () => {
-  Cypress.env('TRANSFORM_SIGNAL', undefined);
-};
-
-export const getTransformSignal = (): TransformSignal | undefined => Cypress.env('TRANSFORM_SIGNAL');
 
 export const getUiVersion = () => {
   return new Cypress.Promise((resolve) => {
@@ -60,16 +62,3 @@ export const getCwd = () => {
 export const hostDetailSelector = (row: number, label: string) =>
   // NOTE: The first row is number 2! Shift your indexes...
   `table.hosts-table > tbody:nth-child(${row}) > tr:nth-child(1) > [data-label="${label}"]`;
-
-export const setHostsRole = (
-  numMasters: number = Cypress.env('NUM_MASTERS'),
-  numWorkers: number = Cypress.env('NUM_WORKERS'),
-) => {
-  // set hosts role
-  for (let i = 2; i < 2 + numMasters; i++) {
-    cy.get(hostDetailSelector(i, 'Role')).click().find('li#master').click();
-  }
-  for (let i = 2 + numMasters; i < 2 + numMasters + numWorkers; i++) {
-    cy.get(hostDetailSelector(i, 'Role')).click().find('li#worker').click();
-  }
-};


### PR DESCRIPTION
- Made dual stack tests independent of each other. Helps for better maintainability and to keep a more focused scope in each test.

- Enhanced the default "signals" to accommodate for more steps related to networking in the tests.